### PR TITLE
Fix a typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN rm /etc/apt/sources.list.d/cuda.list \
     && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
 
 # Install the required packages
-RUN apt-get update && apt-get -y upgrade \
+RUN apt-get update && apt-get -y upgrade
 RUN apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 lsb-core \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There is a typo in the Dockerfile that causes an error during `docker build .`, and this pull request is a fix for it.

Specifically, the line separator(`\`) in line 22 merges two `RUN` commands in lines 22 and 23. This results in executing only the former RUN command, using the latter as an argument.